### PR TITLE
HAL: Allow SERIAL_PPM to be overwritten by defines (buildserver)

### DIFF
--- a/libraries/AP_HAL_MPNG/RCInput_MPNG.cpp
+++ b/libraries/AP_HAL_MPNG/RCInput_MPNG.cpp
@@ -14,12 +14,15 @@ using namespace MPNG;
 extern const HAL& hal;
 
 // PPM_SUM(CPPM) or PWM Signal processing
-#define SERIAL_PPM SERIAL_PPM_ENABLED
+//#define SERIAL_PPM SERIAL_PPM_ENABLED
 /*
 	SERIAL_PPM_DISABLED				// Separated channel signal (PWM) on A8-A15 pins
 	SERIAL_PPM_ENABLED				// For all boards, PPM_SUM pin is A8
 	SERIAL_PPM_ENABLED_PL1		// Use for RCTIMER CRIUS AIOP Pro v2 ONLY, connect your receiver into PPM SUM pin
 */   
+#ifndef SERIAL_PPM
+# define SERIAL_PPM SERIAL_PPM_ENABLED
+#endif
 
 // Uncomment line below in order to use not Standard channel mapping
 //#define RC_MAPPING RC_MAP_STANDARD


### PR DESCRIPTION
I removed the default define for  `SERIAL_PPM` like you did with `RC_MAPPING`.

Edit: after future testing this works great, but there is a bug in the buildserver code which causes the buildserver not getting the latest code somehow.I will currently in the process of fixing the buildserver code.
